### PR TITLE
include version 2.83 LTS

### DIFF
--- a/uv-packer/__init__.py
+++ b/uv-packer/__init__.py
@@ -503,7 +503,7 @@ classes = (UVPackProperty, UVPackerPanel, UVPackerPackButtonOperator, UVPackerSi
 UVPackerRotationButtonOperator, UVPackerFullRotationButtonOperator, UVPackerToolClearMapButtonOperator)
 
 def register():
-  if bpy.app.version < (2, 90, 0):
+  if bpy.app.version < (2, 83, 0):
     return
 
   from bpy.utils import register_class


### PR DESCRIPTION
Blender 2.83 LTS works fine with it (I could not get any error message using it with different packing tests), so I'd suggest to allow users of version 2.83 LTS at least to not get shut out without them adjusting the code them self (which some can, some may not have a clue about how to).