### PR TITLE
Simplify packerDir,PackerExe platform logic

### DIFF
--- a/uv-packer/__init__.py
+++ b/uv-packer/__init__.py
@@ -430,10 +430,11 @@ class UVPackerPackButtonOperator(Operator):
       "Selection": packer_props.uvp_selection_only
     }
 
-    packerDir = "/Applications/UV-Packer-Blender.app/Contents/MacOS/"
+    packerDir = os.path.dirname(os.path.realpath(__file__))
     packerExe = "UV-Packer-Blender"
+    if (platform.system() == 'Darwin'):
+      packerDir = "/Applications/UV-Packer-Blender.app/Contents/MacOS/"
     if (platform.system() == 'Windows'):
-      packerDir = os.path.dirname(os.path.realpath(__file__))
       packerExe = packerExe + ".exe"
 
     try:


### PR DESCRIPTION
On unsupported systems, fall back to looking for the executable with no filename extension inside the addon directory.

This simplifies installation on Linux and other officially unsupported systems where WINE may be used to run the executable.

The additional step for installation is to create an executable text file named `UV-Packer-Blender` in the same location as `UV-Packer-Blender.exe`, with the following contents:.
```sh
#!/bin/sh
export WINEDEBUG=-all
exec wine64 ${0}.exe
```